### PR TITLE
Add adapter for plexus logging

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -65,11 +65,6 @@
       <artifactId>slf4j-api</artifactId>
       <scope>runtime</scope>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>runtime</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/xmvn-core/src/main/java/org/slf4j/impl/PlexusLoggerAdapter.java
+++ b/xmvn-core/src/main/java/org/slf4j/impl/PlexusLoggerAdapter.java
@@ -1,0 +1,266 @@
+/*-
+ * Copyright (c) 2014 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.slf4j.impl;
+
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.io.StringWriter;
+
+import org.codehaus.plexus.DefaultPlexusContainer;
+import org.codehaus.plexus.PlexusContainer;
+import org.codehaus.plexus.PlexusContainerException;
+import org.codehaus.plexus.component.repository.exception.ComponentLookupException;
+import org.codehaus.plexus.logging.Logger;
+import org.slf4j.helpers.FormattingTuple;
+import org.slf4j.helpers.MarkerIgnoringBase;
+import org.slf4j.helpers.MessageFormatter;
+
+
+class PlexusLoggerAdapter
+    extends MarkerIgnoringBase
+{
+    private static final long serialVersionUID = 1L;
+
+    private Logger logger;
+
+    public PlexusLoggerAdapter() {
+        super();
+        try {
+            PlexusContainer container = new DefaultPlexusContainer();
+            logger = container.lookup( Logger.class );
+            container.dispose();
+        } catch ( PlexusContainerException e ) {
+            throw new RuntimeException( e );
+        } catch ( ComponentLookupException e ) {
+            throw new RuntimeException( e );
+        }
+    }
+
+    private String formatMessage( String message, Throwable exception )
+    {
+        if ( exception == null )
+            return message;
+
+        try (StringWriter stringWriter = new StringWriter())
+        {
+            stringWriter.write( message );
+            stringWriter.write( ": " );
+
+            try (PrintWriter printWriter = new PrintWriter( stringWriter ))
+            {
+                exception.printStackTrace( printWriter );
+            }
+
+            return stringWriter.toString();
+        }
+        catch ( IOException e )
+        {
+            throw new RuntimeException( e );
+        }
+    }
+
+    private String formatMessage( String format, Object arg1, Object arg2 )
+    {
+        FormattingTuple tuple = MessageFormatter.format( format, arg1, arg2 );
+        return formatMessage( tuple.getMessage(), tuple.getThrowable() );
+    }
+
+    private String formatMessage( String format, Object... arguments )
+    {
+        FormattingTuple tuple = MessageFormatter.arrayFormat( format, arguments );
+        return formatMessage( tuple.getMessage(), tuple.getThrowable() );
+    }
+
+    @Override
+    public boolean isErrorEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    public void error( String message )
+    {
+        logger.error( message );
+    }
+
+    @Override
+    public void error( String message, Throwable exception )
+    {
+        logger.error( message, exception );
+    }
+
+    @Override
+    public void error( String format, Object arg )
+    {
+        logger.error( formatMessage( format, arg, null ) );
+    }
+
+    @Override
+    public void error( String format, Object arg1, Object arg2 )
+    {
+        logger.error( formatMessage( format, arg1, arg2 ) );
+    }
+
+    @Override
+    public void error( String format, Object... args )
+    {
+        logger.error( formatMessage( format, args ) );
+    }
+
+    @Override
+    public boolean isWarnEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    public void warn( String message )
+    {
+        logger.warn( message );
+    }
+
+    @Override
+    public void warn( String message, Throwable exception )
+    {
+        logger.warn( message, exception );
+    }
+
+    @Override
+    public void warn( String format, Object arg )
+    {
+        logger.warn( formatMessage( format, arg, null ) );
+    }
+
+    @Override
+    public void warn( String format, Object arg1, Object arg2 )
+    {
+        logger.warn( formatMessage( format, arg1, arg2 ) );
+    }
+
+    @Override
+    public void warn( String format, Object... args )
+    {
+        logger.warn( formatMessage( format, args ) );
+    }
+
+    @Override
+    public boolean isInfoEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    public void info( String message )
+    {
+        logger.info( message );
+    }
+
+    @Override
+    public void info( String message, Throwable exception )
+    {
+        logger.info( message, exception );
+    }
+
+    @Override
+    public void info( String format, Object arg )
+    {
+        logger.info( formatMessage( format, arg, null ) );
+    }
+
+    @Override
+    public void info( String format, Object arg1, Object arg2 )
+    {
+        logger.info( formatMessage( format, arg1, arg2 ) );
+    }
+
+    @Override
+    public void info( String format, Object... args )
+    {
+        logger.info( formatMessage( format, args ) );
+    }
+
+    @Override
+    public boolean isDebugEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    public void debug( String message )
+    {
+        logger.debug( message );
+    }
+
+    @Override
+    public void debug( String format, Object param1 )
+    {
+        logger.debug( formatMessage( format, param1, null ) );
+    }
+
+    @Override
+    public void debug( String format, Object param1, Object param2 )
+    {
+        logger.debug( formatMessage( format, param1, param2 ) );
+    }
+
+    @Override
+    public void debug( String format, Object... args )
+    {
+        logger.debug( formatMessage( format, args ) );
+    }
+
+    @Override
+    public void debug( String message, Throwable exception )
+    {
+        logger.debug( message, exception );
+    }
+
+    @Override
+    public boolean isTraceEnabled()
+    {
+        return true;
+    }
+
+    @Override
+    public void trace( String message )
+    {
+        logger.debug( message );
+    }
+
+    @Override
+    public void trace( String message, Throwable exception )
+    {
+        logger.debug( message, exception );
+    }
+
+    @Override
+    public void trace( String format, Object param1 )
+    {
+        logger.debug( formatMessage( format, param1, null ) );
+    }
+
+    @Override
+    public void trace( String format, Object param1, Object param2 )
+    {
+        logger.debug( formatMessage( format, param1, param2 ) );
+    }
+
+    @Override
+    public void trace( String format, Object... args )
+    {
+        logger.debug( formatMessage( format, args ) );
+    }
+}

--- a/xmvn-core/src/main/java/org/slf4j/impl/PlexusLoggerFactory.java
+++ b/xmvn-core/src/main/java/org/slf4j/impl/PlexusLoggerFactory.java
@@ -1,0 +1,35 @@
+/*-
+ * Copyright (c) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.slf4j.impl;
+
+import org.slf4j.ILoggerFactory;
+import org.slf4j.Logger;
+
+
+class PlexusLoggerFactory
+    implements ILoggerFactory
+{
+    private static class Lazy
+    {
+        static final Logger INSTANCE = new PlexusLoggerAdapter();
+    }
+
+    @Override
+    public Logger getLogger( String arg0 )
+    {
+        return Lazy.INSTANCE;
+    }
+}

--- a/xmvn-core/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
+++ b/xmvn-core/src/main/java/org/slf4j/impl/StaticLoggerBinder.java
@@ -1,0 +1,53 @@
+/*-
+ * Copyright (c) 2015 Red Hat, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.slf4j.impl;
+
+import org.slf4j.ILoggerFactory;
+import org.slf4j.spi.LoggerFactoryBinder;
+
+
+public class StaticLoggerBinder
+    implements LoggerFactoryBinder
+{
+    public static String REQUESTED_API_VERSION = "1.6.99";
+
+    private static final StaticLoggerBinder INSTANCE = new StaticLoggerBinder();
+
+    private static final String FACTORY_CLASS = PlexusLoggerFactory.class.getName();
+
+    private static final ILoggerFactory FACTORY = new PlexusLoggerFactory();
+
+    private StaticLoggerBinder()
+    {
+    }
+
+    public static final StaticLoggerBinder getSingleton()
+    {
+        return INSTANCE;
+    }
+
+    @Override
+    public ILoggerFactory getLoggerFactory()
+    {
+        return FACTORY;
+    }
+
+    @Override
+    public String getLoggerFactoryClassStr()
+    {
+        return FACTORY_CLASS;
+    }
+}

--- a/xmvn-parent/pom.xml
+++ b/xmvn-parent/pom.xml
@@ -286,11 +286,6 @@
       <artifactId>easymock</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <repositories>
     <repository>

--- a/xmvn-tools/pom.xml
+++ b/xmvn-tools/pom.xml
@@ -56,10 +56,5 @@
       <artifactId>sisu-guice</artifactId>
       <classifier>no_aop</classifier>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-      <scope>runtime</scope>
-    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
This is an initial attempt to introduce adapter for plexus logging. Tests for xmvn-install fail:
```
java.lang.ExceptionInInitializerError: null
	at org.sonatype.guice.bean.reflect.Logs$SLF4JSink.isDebugEnabled(Logs.java:385)
	at org.sonatype.guice.bean.reflect.Logs.<clinit>(Logs.java:78)
	at org.sonatype.guice.plexus.scanners.PlexusTypeRegistry.addComponent(PlexusTypeRegistry.java:156)
	at org.sonatype.guice.plexus.scanners.PlexusXmlScanner.parseComponent(PlexusXmlScanner.java:329)
	at org.sonatype.guice.plexus.scanners.PlexusXmlScanner.parseComponentsXml(PlexusXmlScanner.java:198)
	at org.sonatype.guice.plexus.scanners.PlexusXmlScanner.scan(PlexusXmlScanner.java:94)
	at org.sonatype.guice.plexus.binders.PlexusXmlBeanModule.configure(PlexusXmlBeanModule.java:89)
	at org.sonatype.guice.plexus.binders.PlexusBindingModule.configure(PlexusBindingModule.java:62)
	at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:230)
	at com.google.inject.spi.Elements.getElements(Elements.java:103)
	at com.google.inject.spi.Elements.getElements(Elements.java:80)
	at org.sonatype.guice.bean.binders.MergedModule.configure(MergedModule.java:54)
	at com.google.inject.spi.Elements$RecordingBinder.install(Elements.java:230)
	at com.google.inject.spi.Elements.getElements(Elements.java:103)
	at com.google.inject.internal.InjectorShell$Builder.build(InjectorShell.java:136)
	at com.google.inject.internal.InternalInjectorCreator.build(InternalInjectorCreator.java:104)
	at com.google.inject.Guice.createInjector(Guice.java:96)
	at com.google.inject.Guice.createInjector(Guice.java:73)
	at com.google.inject.Guice.createInjector(Guice.java:62)
	at org.codehaus.plexus.DefaultPlexusContainer.addPlexusInjector(DefaultPlexusContainer.java:470)
	at org.codehaus.plexus.DefaultPlexusContainer.<init>(DefaultPlexusContainer.java:196)
	at org.codehaus.plexus.DefaultPlexusContainer.<init>(DefaultPlexusContainer.java:160)
	at org.codehaus.plexus.DefaultPlexusContainer.<init>(DefaultPlexusContainer.java:154)
	at org.slf4j.impl.PlexusLoggerAdapter.<init>(PlexusLoggerAdapter.java:42)
	at org.slf4j.impl.PlexusLoggerFactory$Lazy.<clinit>(PlexusLoggerFactory.java:27)
	at org.slf4j.impl.PlexusLoggerFactory.getLogger(PlexusLoggerFactory.java:33)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:277)
	at org.slf4j.LoggerFactory.getLogger(LoggerFactory.java:288)
	at org.fedoraproject.xmvn.tools.install.impl.JarUtils.<clinit>(JarUtils.java:45)
	at org.fedoraproject.xmvn.tools.install.impl.JarUtilsTest.testManifestInjection(JarUtilsTest.java:67)
```
How I understand it: My PlexusLoggerAdapter (SLF4J logger impl.) needs to initialize PlexusContainer, but PlexusContainer uses sisu-guice, which at one point requests implementation of SLF4J logger, i.e. chicken/egg problem.

What do you think Mikolaj?