### PR TITLE
Allow xmvn to install files who names contains spaces

### DIFF
--- a/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/File.java
+++ b/xmvn-tools/xmvn-install/src/main/java/org/fedoraproject/xmvn/tools/install/File.java
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014-2015 Red Hat, Inc.
+ * Copyright (c) 2014-2017 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -161,8 +161,21 @@ public abstract class File
             sb.append( ' ' );
         }
 
+        // Paths containing whitespace (e.g. one of [ \t\n\v\f\r]) must be quoted in the descriptor
+        boolean needsQuote = targetPath.toString().matches( ".*\\s+.*" );
+
+        if ( needsQuote )
+        {
+            sb.append( '"' );
+        }
+
         sb.append( '/' );
         sb.append( targetPath );
+
+        if ( needsQuote )
+        {
+            sb.append( '"' );
+        }
 
         return sb.toString();
     }

--- a/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/JavaPackageTest.java
+++ b/xmvn-tools/xmvn-install/src/test/java/org/fedoraproject/xmvn/tools/install/JavaPackageTest.java
@@ -1,5 +1,5 @@
 /*-
- * Copyright (c) 2014-2015 Red Hat, Inc.
+ * Copyright (c) 2014-2017 Red Hat, Inc.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -59,5 +59,34 @@ public class JavaPackageTest
         PackageMetadata actualMetadata =
             new MetadataStaxReader().read( installRoot.resolve( metadataPath ).toString(), true );
         assertEquals( "test-uuid", actualMetadata.getUuid() );
+    }
+
+    @Test
+    public void testSpacesInFileNames() throws Exception
+    {
+        JavaPackage pkg = new JavaPackage( "space-test",
+                Paths.get( "usr/share/maven-metadata/space-test.xml" ) );
+        pkg.addFile( new RegularFile(
+                Paths.get(
+                        "usr/share/eclipse/droplets/space-test/plugins/space-test_1.0.0/META-INF/MANIFEST.MF" ),
+                new byte[0] ) );
+        pkg.addFile( new RegularFile(
+                Paths.get(
+                        "usr/share/eclipse/droplets/space-test/plugins/space-test_1.0.0/file with spaces" ),
+                new byte[0] ) );
+        pkg.addFile( new RegularFile(
+                Paths.get(
+                        "usr/share/eclipse/droplets/space-test/plugins/space-test_1.0.0/other\twhitespace" ),
+                new byte[0] ) );
+        pkg.addFile( new RegularFile(
+                Paths.get(
+                        "usr/share/eclipse/droplets/space-test/plugins/space-test_1.0.0/other\u000Bwhitespace" ),
+                new byte[0] ) );
+        assertDescriptorEquals( pkg,
+                "%attr(0644,root,root) /usr/share/eclipse/droplets/space-test/plugins/space-test_1.0.0/META-INF/MANIFEST.MF",
+                "%attr(0644,root,root) \"/usr/share/eclipse/droplets/space-test/plugins/space-test_1.0.0/file with spaces\"",
+                "%attr(0644,root,root) \"/usr/share/eclipse/droplets/space-test/plugins/space-test_1.0.0/other\twhitespace\"",
+                "%attr(0644,root,root) \"/usr/share/eclipse/droplets/space-test/plugins/space-test_1.0.0/other\u000Bwhitespace\"",
+                "%attr(0644,root,root) /usr/share/maven-metadata/space-test.xml" );
     }
 }


### PR DESCRIPTION
Eclipse plugins may be installed as "dir-shaped" bundles, which means
that they will be installed as exploded directory trees instead of
ordinary jar files. If such a bundle contains a file that has a space
in its name, then this will cause RPM build failure due to RPM mis-
interpreting the descriptor line as two separate paths instead of a
single path containing a space.

This change adds quoting to paths that contain spaces when writing
the descriptor.